### PR TITLE
Fix multiple definition problem for BooPHF.h

### DIFF
--- a/BooPHF.h
+++ b/BooPHF.h
@@ -23,7 +23,7 @@
 namespace boomphf {
 
 	
-	u_int64_t printPt( pthread_t pt) {
+	inline u_int64_t printPt( pthread_t pt) {
 	  unsigned char *ptc = (unsigned char*)(void*)(&pt);
 		u_int64_t res =0;
 	  for (size_t i=0; i<sizeof(pt); i++) {


### PR DESCRIPTION
BooPHF.h contains a definition of the function `printPt` which 
generates a multiple definition error when included in separate linking 
units.  This patch declares the function as inline, which eliminates that problem.